### PR TITLE
Fix team policy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,8 +54,7 @@
         "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true,
-            "phpstan/extension-installer": gsue,
-
+            "phpstan/extension-installer": true
         }
     },
     "extra": {

--- a/src/TeamManagementServiceProvider.php
+++ b/src/TeamManagementServiceProvider.php
@@ -2,12 +2,26 @@
 
 namespace Stats4sd\TeamManagement;
 
+use Illuminate\Support\Facades\Gate;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Stats4sd\TeamManagement\Commands\TeamManagementCommand;
+use Stats4sd\TeamManagement\Models\Team;
+use Stats4sd\TeamManagement\Policies\TeamPolicy;
 
 class TeamManagementServiceProvider extends PackageServiceProvider
 {
+    protected $policies = [
+        Team::class => TeamPolicy::class,
+    ];
+
+public function registerPolicies()
+    {
+        foreach ($this->policies as $key => $value) {
+            Gate::policy($key, $value);
+        }
+    }
+
     public function configurePackage(Package $package): void
     {
         /*
@@ -19,5 +33,11 @@ class TeamManagementServiceProvider extends PackageServiceProvider
             ->name('laravel-team-management')
             ->hasConfigFile()
             ->hasViews();
+    }
+
+    public function boot()
+    {
+        $this->registerPolicies();
+        return parent::boot();
     }
 }


### PR DESCRIPTION
The TeamPolicy, which defines who can and cannot do various activities related to teams, was not working. Turns out in a package you need to manually register the policy+model combos in the Service Provider... 

This PR fixes the issue. Now, site admins (and team admins) can invite members and edit existing members:

Before:
![CleanShot 2023-01-18 at 14 59 30](https://user-images.githubusercontent.com/5711101/213205683-79c56f16-6959-4819-8995-8a7060139e13.png)

After:
![CleanShot 2023-01-18 at 14 59 18](https://user-images.githubusercontent.com/5711101/213205726-cd0cf8bf-f33a-47d9-b644-f67bfb14dc35.png)
